### PR TITLE
Support BCC 0.16.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/iovisor/gobpf v0.0.0-20191110090744-d63e8dd5f0a5 // indirect
 	github.com/onsi/gomega v1.7.1
-	github.com/josephvoss/gobpf v0.8.0-1
+	github.com/josephvoss/gobpf v0.16.0-1
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,0 @@
-github.com/iovisor/gobpf v0.0.0-20191110090744-d63e8dd5f0a5 h1:GrEIV5nwaiSMnoc3jnePlC6QHyqaxEfmoGoQlZODBmg=
-github.com/iovisor/gobpf v0.0.0-20191110090744-d63e8dd5f0a5/go.mod h1:+5U5qu5UOu8YJ5oHVLvWKH7/Dr5QNHU7mZ2RfPEeXg8=
-github.com/josephvoss/gobpf v0.8.0-1 h1:UTvbW9LBIh83V0GsB/UP0dMIaAZ3zLuQZ8HFwAPyraE=
-github.com/josephvoss/gobpf v0.8.0-1/go.mod h1:zCLlD+AXWljPdqoNRWhcm0UohbUvYlRfg4PgktWabOI=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
-gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"sync"
 
+	bcc "github.com/josephvoss/gobpf/bcc"
 	"github.com/olcf/greggd/pkg/communication"
 	"github.com/olcf/greggd/pkg/config"
-	bcc "github.com/josephvoss/gobpf/bcc"
 )
 
 // Watch each configured memory map. Read perf events as they are sent.
@@ -42,7 +42,8 @@ func pollOutputMaps(ctx context.Context, output config.BPFOutput,
 		inputChan := make(chan []byte)
 		defer close(inputChan)
 
-		perfMap, err := bcc.InitPerfMap(table, inputChan)
+		// Lost perf messages chan not implemented, set to nil
+		perfMap, err := bcc.InitPerfMap(table, inputChan, nil)
 		if err != nil {
 			errChan <- fmt.Errorf("tracer.go: Error building perf map: %s\n", err)
 			return
@@ -83,7 +84,8 @@ func attachAndLoadEvent(event config.BPFEvent, m *bcc.Module) error {
 			return err
 		}
 
-		err = m.AttachKprobe(event.AttachTo, fd)
+		// use kernel default for maxactive instances probed simultaneously
+		err = m.AttachKprobe(event.AttachTo, fd, -1)
 		if err != nil {
 			return err
 		}
@@ -93,7 +95,8 @@ func attachAndLoadEvent(event config.BPFEvent, m *bcc.Module) error {
 			return err
 		}
 
-		err = m.AttachKretprobe(event.AttachTo, fd)
+		// use kernel default for maxactive instances probed simultaneously
+		err = m.AttachKretprobe(event.AttachTo, fd, -1)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Update gobpf module to BCC v0.16.0 and fix changed gobpf function calls.